### PR TITLE
DST-6373 Role caches populated incorrectly

### DIFF
--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserRoleGroupServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserRoleGroupServiceImpl.java
@@ -44,15 +44,12 @@ public class UserRoleGroupServiceImpl implements UserRoleGroupService
     }
 
     @Override
-    public Optional<RoleGroup> getRoleGroup(String name)
-	{
+	public Optional<RoleGroup> getRoleGroup(String name) {
 		val rolesICanAssign = userRoleService.getRolesICanAssign().stream().map(RoleEntry::getName).collect(toSet());
-        return roleGroupService.getRoleGroup(name)
-				.map(g -> {
-					g.setRoles(g.getRoles().stream()
-							.filter(role -> rolesICanAssign.contains(role.getName()))
-							.collect(toList()));
-					return g;
-				});
-    }
+		return roleGroupService.getRoleGroup(name).map(g -> RoleGroup.builder()
+				.name(g.getName())
+				.roles(g.getRoles().stream()
+						.filter(role -> rolesICanAssign.contains(role.getName()))
+						.collect(toList())).build());
+	}
 }


### PR DESCRIPTION
Return a new role group instead of filtering the roles on the existing one. This is to prevent the cache from being updated with a role group that has been modified to be user-specific.

Fixes https://jira.engineering-dev.probation.hmpps.dsd.io/browse/DST-6373

