### PR TITLE
Auto-deploy to Test environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
             }
         }
         stage('Deploy') {
-            when { branch 'feature/auto-deploy' }
+            when { branch 'master' }
             steps {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
                     sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                         AWS_SECRET_ACCESS_KEY="`echo \$creds | jq -r '.Credentials.SecretAccessKey'`"
                         AWS_SESSION_TOKEN="`echo \$creds | jq -r '.Credentials.SessionToken'`"
                         echo "Starting deployment..."
-                        aws ecs update-service --cluster del-delius-ecscluster-private-ecs --service del-test-usermanagement-service --force-new-deployment
+                        aws ecs update-service --region eu-west-2 --cluster del-delius-ecscluster-private-ecs --service del-test-usermanagement-service --force-new-deployment
                     '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
             steps {
                 wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
                     sh '''
+                        set +x
                         echo "Assuming role in Test account..."
                         creds=`aws sts assume-role --role-arn arn:aws:iam::728765553488:role/terraform --role-session-name deploy-usermanagement-\$RANDOM`
                         export AWS_ACCESS_KEY_ID="`echo \$creds | jq -r '.Credentials.AccessKeyId'`"
@@ -68,6 +69,10 @@ pipeline {
                         aws sts get-caller-identity
                         echo "Starting deployment..."
                         aws ecs update-service --region eu-west-2 --cluster del-delius-ecscluster-private-ecs --service del-test-usermanagement-service --force-new-deployment
+                        unset AWS_ACCESS_KEY_ID
+                        unset AWS_SECRET_ACCESS_KEY
+                        unset AWS_SESSION_TOKEN
+                        set -x
                     '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,9 +62,10 @@ pipeline {
                     sh '''
                         echo "Assuming role in Test account..."
                         creds=`aws sts assume-role --role-arn arn:aws:iam::728765553488:role/terraform --role-session-name deploy-usermanagement-\$RANDOM`
-                        AWS_ACCESS_KEY_ID="`echo \$creds | jq -r '.Credentials.AccessKeyId'`"
-                        AWS_SECRET_ACCESS_KEY="`echo \$creds | jq -r '.Credentials.SecretAccessKey'`"
-                        AWS_SESSION_TOKEN="`echo \$creds | jq -r '.Credentials.SessionToken'`"
+                        export AWS_ACCESS_KEY_ID="`echo \$creds | jq -r '.Credentials.AccessKeyId'`"
+                        export AWS_SECRET_ACCESS_KEY="`echo \$creds | jq -r '.Credentials.SecretAccessKey'`"
+                        export AWS_SESSION_TOKEN="`echo \$creds | jq -r '.Credentials.SessionToken'`"
+                        aws sts get-caller-identity
                         echo "Starting deployment..."
                         aws ecs update-service --region eu-west-2 --cluster del-delius-ecscluster-private-ecs --service del-test-usermanagement-service --force-new-deployment
                     '''


### PR DESCRIPTION
This is to replicate the functionality we had pre-AWS, whereby any merge to master in the User Management repo would automatically be built and deployed to Test for quick feedback on stories/bugs.

The Jenkinsfile already builds and pushes the Docker image to ECR. This PR adds a step to force a new deployment of the usermanagement service in the Test account, which will pick up the latest snapshot image.

Tested in Jenkins from the branch here: https://jenkins.engineering-dev.probation.hmpps.dsd.io/job/DAMS/job/Artefacts/job/Delius/job/User%20Management%20Tool/job/feature%252Fauto-deploy/6/console