### PR TITLE
Fix role lookup in environments where roles are associated using NDRole instead of NDRoleAssociation (eg Training)

### DIFF
--- a/src/main/java/uk/co/bconline/ndelius/service/impl/RoleServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/RoleServiceImpl.java
@@ -59,7 +59,10 @@ public class RoleServiceImpl implements RoleService
 	@Cacheable(value = "rolesets", key = "'all'")
 	public Set<RoleEntry> getAllRoles()
 	{
-		return Sets.newHashSet(roleRepository.findAll());
+		return Sets.newHashSet(roleRepository.findAll(query()
+				.searchScope(ONELEVEL)
+				.base(rolesBase)
+				.where(OBJECTCLASS).is("NDRole")));
 	}
 
 	@Override


### PR DESCRIPTION
This change ensures that when looking for all roles, it only looks in the role catalogue and nowhere else. In case there are erroneous NDRole entries elsewhere in the LDAP - which there shouldn't be, but there is in the Training environment.