### PR TITLE
Prevent caching of index.html

### DIFF
--- a/src/main/java/uk/co/bconline/ndelius/config/security/WebMvcConfig.java
+++ b/src/main/java/uk/co/bconline/ndelius/config/security/WebMvcConfig.java
@@ -1,6 +1,8 @@
 package uk.co.bconline.ndelius.config.security;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -8,6 +10,16 @@ import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addResourceHandlers(final ResourceHandlerRegistry registry) {
+		// Prevent caching of index.html, so that Angular cache-busting works correctly
+		registry.addResourceHandler("/index.html")
+				.addResourceLocations("classpath:static/index.html")
+				.setCacheControl(CacheControl.noStore())
+				.setCachePeriod(0);
+	}
+
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
 		registry.addViewController("/login").setViewName("login");


### PR DESCRIPTION
 so that Angular cache-busting works correctly. This ensures users don't need to clear their browser cache when a new version is deployed.