### PR TITLE
DST-9180 - Teams dropdown selectable when staff code has not been set

### DIFF
--- a/ui/src/app/component/item-selector/item-selector.component.html
+++ b/ui/src/app/component/item-selector/item-selector.component.html
@@ -7,7 +7,7 @@
           (keydown.arrowdown)="collapseDropdown() && $event.stopPropagation()"
           (keydown.alt.arrowup)="collapseDropdown() && $event.stopPropagation()"
           (keydown.alt.arrowdown)="collapseDropdown() && $event.stopPropagation()"
-          [disabled]="available == null || (available.length == 0 && subMenuItems == null) || (subMenuItems != null && subMenuItems.length == 0)"
+          [disabled]="disableComponent()"
           [class.readonly]="readonly"
           [class.ng-dirty]="dirty"
           [title]="displayText"

--- a/ui/src/app/component/item-selector/item-selector.component.ts
+++ b/ui/src/app/component/item-selector/item-selector.component.ts
@@ -56,7 +56,7 @@ export class ItemSelectorComponent
   @Input() loadingText = 'Loading...';
   @Input() subMenuItems: {code: string, description: string}[];
   @Input() selectedSubMenuItem: string;
-
+  @Input() disabled: boolean;
   @Output() selectedChange: EventEmitter<any> = new EventEmitter<any>();
   private availableItems: any[];
 
@@ -243,5 +243,15 @@ export class ItemSelectorComponent
     this.getSubMenu(this.selectedSubMenuItem).subscribe(
       items => this.available = items
     );
+  }
+
+  disableComponent(): boolean {
+    // If using a subMenu then the component is disabled when the subMenu has no items
+    // Otherwise the item-selector is disabled when the available field is empty
+    if (this.subMenuItems == null || this.subMenuItems.length === 0) {
+      return this.available == null || this.available.length === 0 || this.disabled;
+    } else {
+      return this.subMenuItems.length === 0 || this.disabled;
+    }
   }
 }

--- a/ui/src/app/component/user/user.component.html
+++ b/ui/src/app/component/user/user.component.html
@@ -353,6 +353,7 @@
           <div class="col-sm-4">
             <item-selector id="teams" name="teams" multiple="true" #teamsList="ngModel" maxHeight="300px"
                            [(ngModel)] = "user.teams"
+                           [disabled]="user.staffCode == null || user.staffCode == ''"
                            [(selected)]="user.teams"
                            [available]="teams"
                            [subMenuItems]="user.datasets"

--- a/ui/src/app/component/user/user.component.ts
+++ b/ui/src/app/component/user/user.component.ts
@@ -179,6 +179,9 @@ export class UserComponent implements OnInit {
   }
 
   staffCodeChanged(): void {
+    if (!this.user.staffCode) {
+      this.user.teams = null;
+    }
     this.userWithStaffCode = null;
     this.loadingStaffCode = true;
     this.userService.readByStaffCode(this.user.staffCode)


### PR DESCRIPTION
- Added logic to disable Item Selector component when using a subMenu with no available selections
- Added disabled property to Item Selector
- Disabled the teams drop down when the staffCode is null or empty
- Set the teams dropdown to null when the staffCode field is cleared