### PR TITLE
DST-9227 - Fix for 500 error when performing a role search

### DIFF
--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserRoleServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserRoleServiceImpl.java
@@ -160,7 +160,7 @@ public class UserRoleServiceImpl implements UserRoleService {
 		return stream(roleAssociationRepository.findAll(query()
 				.searchScope(SUBTREE)
 				.base(usersBase)
-				.where(OBJECTCLASS).is("NDRoleAssociation").and("cn").like(role)).spliterator(), true)
+				.where(OBJECTCLASS).is("NDRoleAssociation").and("cn").like(role)).spliterator(), false)
 				.map(user -> LdapUtils.getStringValue(user.getDn(), user.getDn().size() - 2).toLowerCase()) // username is 2nd-to-last part of distinguished name
 				.collect(toList());
 	}

--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserServiceImpl.java
@@ -112,7 +112,7 @@ public class UserServiceImpl implements UserService {
 		// Create Futures to search the LDAP and Database asynchronously
 		val dbFuture = supplyAsync(() -> userEntityService.search(query, includeInactiveUsers, datasetFilter), taskExecutor);
 		val ldapFuture = supplyAsync(() -> userEntryService.search(query, includeInactiveUsers, datasetFilter), taskExecutor);
-		val roleFuture = supplyAsync(() -> userRoleService.getAllUsersWithRole(role));
+		val roleFuture = supplyAsync(() -> userRoleService.getAllUsersWithRole(role), taskExecutor);
 
 		try {
 			// fetch and map


### PR DESCRIPTION
Added task executor to the role search's future to resolve 500 server errors on certain environments when performing a role search.