### PR TITLE
DST-9458 Fix timeouts due to unnecessary `expandEmailInSearch` calls

### DIFF
--- a/src/main/java/uk/co/bconline/ndelius/service/GroupService.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/GroupService.java
@@ -11,8 +11,9 @@ import java.util.Set;
 public interface GroupService {
     Map<String, Set<GroupEntry>> getGroups();
     Set<GroupEntry> getGroups(String type);
-    Set<GroupEntry> getGroups(Collection<Name> groupNames);
+	Set<GroupEntry> getGroups(Collection<Name> groupNames);
     Optional<GroupEntry> getGroup(String name);
     Optional<GroupEntry> getGroup(String type, String name);
+	Set<String> getAllUsersInGroups(Map<String, Set<String>> groups);
     void save(GroupEntry group);
 }

--- a/src/main/java/uk/co/bconline/ndelius/service/impl/GroupServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/GroupServiceImpl.java
@@ -81,6 +81,16 @@ public class GroupServiceImpl implements GroupService {
 	}
 
 	@Override
+	public Set<String> getAllUsersInGroups(Map<String, Set<String>> groups) {
+		return groups.keySet().parallelStream()
+				.flatMap(type -> groups.get(type).parallelStream().map(name -> getGroup(type, name)))
+				.flatMap(Optionals::toStream)
+				.flatMap(group -> group.getMembers().stream())
+				.map(name -> LdapUtils.getStringValue(name, "cn").toLowerCase())
+				.collect(toSet());
+	}
+
+	@Override
 	public void save(GroupEntry group) {
 		groupRepository.save(group);
 	}

--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserEntryServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserEntryServiceImpl.java
@@ -119,7 +119,7 @@ public class UserEntryServiceImpl implements UserEntryService, UserDetailsServic
 	public List<SearchResult> search(String query, boolean includeInactiveUsers, Set<String> datasets) {
 		// For a search with no dataset filtering, we don't need to search LDAP as all the users will be returned by the DB search
 		// (We only ever need to search LDAP to find users that match on userHomeArea or email - as these attributes do not exist in the DB)
-		if (datasets.isEmpty() && !includeInactiveUsers && !query.contains("@")) return emptyList();
+		if (datasets.isEmpty() && !includeInactiveUsers && !SearchUtils.isEmailSearch(query)) return emptyList();
 
 		// Build up tokenized filter on givenName (forenames), sn (surname) and cn (username)
 		AndFilter filter = Stream.of(query.trim().split("\\s+"))

--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserServiceImpl.java
@@ -281,10 +281,10 @@ public class UserServiceImpl implements UserService {
 		return myDatasets;
 	}
 
-
 	private SearchResult expandEmailSearchToDB(SearchResult ldapResult, String query) {
-		if (ldapResult.getEmail() != null && SearchUtils.streamTokens(query).anyMatch(ldapResult.getEmail()::contains)) {
-			// Search the database to obtain staff and team records if the token is a substring of the search result's email
+		// If a search result was matched on email address only (from the LDAP), then we may need to fetch additional details from the Database
+		if (SearchUtils.isEmailSearch(query) && SearchUtils.resultMatchedOnEmail(query, ldapResult)) {
+			// Search the database to obtain staff and team records
 			return userEntityService.getUser(ldapResult.getUsername())
 					.map(searchResultTransformer::map)
 					.map(dbResult -> searchResultTransformer.reduce(ldapResult, dbResult))

--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserServiceImpl.java
@@ -6,7 +6,6 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.util.Optionals;
-import org.springframework.ldap.support.LdapUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.co.bconline.ndelius.exception.AppException;
@@ -100,23 +99,15 @@ public class UserServiceImpl implements UserService {
 			}
 		}
 
-		// Create a Future to fetch the members of all the groups that are being filtered on
-		val groupMembersFuture = supplyAsync(() -> groupFilter.keySet().parallelStream()
-				.flatMap(type -> groupFilter.get(type).parallelStream()
-						.map(name -> groupService.getGroup(type, name)))
-				.flatMap(Optionals::toStream)
-				.flatMap(group -> group.getMembers().stream())
-				.map(name -> LdapUtils.getStringValue(name, "cn").toLowerCase())
-				.collect(toSet()), taskExecutor);
-
 		// Create Futures to search the LDAP and Database asynchronously
 		val dbFuture = supplyAsync(() -> userEntityService.search(query, includeInactiveUsers, datasetFilter).stream(), taskExecutor);
 		val ldapFuture = supplyAsync(() -> userEntryService.search(query, includeInactiveUsers, datasetFilter).stream(), taskExecutor);
 		val roleFuture = supplyAsync(() -> userRoleService.getAllUsersWithRole(role), taskExecutor);
+		val groupFuture = supplyAsync(() -> groupService.getAllUsersInGroups(groupFilter), taskExecutor);
 
 		try {
 			// fetch and combine
-			var stream = allOf(groupMembersFuture, ldapFuture, dbFuture, roleFuture)
+			var stream = allOf(ldapFuture, dbFuture, roleFuture, groupFuture)
 					.thenApply(v -> Stream.concat(
 							ldapFuture.join().map(sr -> expandEmailSearchToDB(sr, query)),
 							dbFuture.join()
@@ -129,7 +120,7 @@ public class UserServiceImpl implements UserService {
 				stream = stream.filter(result -> result.getEndDate() == null || !result.getEndDate().isBefore(now()));
 			}
 			if (!groupFilterIsEmpty) {
-				stream = stream.filter(result -> groupMembersFuture.join().contains(result.getUsername().toLowerCase()));
+				stream = stream.filter(result -> groupFuture.join().contains(result.getUsername().toLowerCase()));
 			}
 			if (!roleIsEmpty) {
 				stream = stream.filter(result -> roleFuture.join().contains(result.getUsername().toLowerCase()));

--- a/src/main/java/uk/co/bconline/ndelius/util/SearchUtils.java
+++ b/src/main/java/uk/co/bconline/ndelius/util/SearchUtils.java
@@ -1,6 +1,7 @@
 package uk.co.bconline.ndelius.util;
 
 import lombok.experimental.UtilityClass;
+import uk.co.bconline.ndelius.model.SearchResult;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -16,5 +17,16 @@ public class SearchUtils {
 
 	public static Stream<String> streamTokens(String query) {
 		return Arrays.stream(tokenize(query));
+	}
+
+	public static boolean isEmailSearch(String query) {
+		// If the search query contains an '@' symbol, then assume the user is searching for an email address
+		// (this is a very rough heuristic, but seems to work well in practice)
+		return query != null && query.contains("@");
+	}
+
+	public static boolean resultMatchedOnEmail(String query, SearchResult result) {
+		// If the result's email address contains one of the search tokens, then assume it was matched on email
+		return result.getEmail() != null && SearchUtils.streamTokens(query).anyMatch(result.getEmail()::contains);
 	}
 }


### PR DESCRIPTION
This helps to resolve timeouts in Production when filtering by dataset only (with a blank query string).