### PR TITLE
Skip dependency-check analysis for "zinc" dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ plugins.withType(JacocoPlugin) {
 // Dependency vulnerability scanning
 dependencyCheck {
 	suppressionFile = 'dependency-check-suppression.xml'
+	skipConfigurations = ['zinc'] // zinc is the Scala incremental compiler used for Gatling tests, and can be ignored
 	failBuildOnCVSS = 4
 	// CVSS scoring: https://nvd.nist.gov/vuln-metrics/cvss
 	// None     0.0


### PR DESCRIPTION
The zinc compiler, pulled in by the recently added Gatling test plugin, uses Scala 2.12 which depends on jQuery 1.4.2. This results in false positives for CVE-2020-11022 and CVE-2020-11023.