### PR TITLE
Disable DependencyCheck assembly analyzer.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ plugins.withType(JacocoPlugin) {
 // Dependency vulnerability scanning
 dependencyCheck {
 	suppressionFile = 'dependency-check-suppression.xml'
+	analyzers.assemblyEnabled = false
 	skipConfigurations = ['zinc'] // zinc is the Scala incremental compiler used for Gatling tests, and can be ignored
 	failBuildOnCVSS = 4 // Medium severity or higher. See https://nvd.nist.gov/vuln-metrics/cvss
 }


### PR DESCRIPTION
It is triggered by the redis-server executable in the embedded-redis dependency, and causes the task to fail in some CI environments.