### PR TITLE
Suppress CVE-2022-24823 Netty vulnerability

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>This only impacts applications running on Java version 6 and lower</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*$</packageUrl>
+        <cve>CVE-2022-24823</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
This only impacts applications running on Java version 6 and lower.