### PR TITLE
DST-20207 Fixes to improve backward-compatibility

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -107,11 +107,11 @@ The front-end application authenticates with the back-end using the [Authorizati
 The following commands show how you can authenticate as a user (`test.user`) to authorize a client (`test.web.client`), using the Authorization Code flow.
 ```shell script
 # User gets an authorization code
-> curl -X GET -u 'test.user:secret' 'http://localhost:8080/umt/oauth2/authorize?client_id=test.web.client&response_type=code&redirect_uri=/login-success'
+> curl -X GET -u 'test.user:secret' 'http://localhost:8080/umt/oauth/authorize?client_id=test.web.client&response_type=code&redirect_uri=/login-success'
 < 303 See Other: /login-success?code=<auth_code>
 
 # Client swaps the authorization code for an access token
-> curl -X POST -u 'test.web.client:secret' 'http://localhost:8080/umt/oauth2/token?code=<auth_code>&grant_type=authorization_code&redirect_uri=/login-success'
+> curl -X POST -u 'test.web.client:secret' 'http://localhost:8080/umt/oauth/token?code=<auth_code>&grant_type=authorization_code&redirect_uri=/login-success'
 < {"access_token":"<token>", ...}
 
 # Client sends the access token in the Authoriation header to access API resources
@@ -134,12 +134,12 @@ When NDelius constructs the URL for the external service, it will append two par
 
 Both parameters will be encrypted by NDelius using a symmetric key that is shared between NDelius and UMT (configured using `delius.secret`).
 
-These two parameters should then be provided to the `/oauth2/token` endpoint with `grant_type=preauthenticated`.
+These two parameters should then be provided to the `/oauth/token` endpoint with `grant_type=preauthenticated`.
 The parameters will be verified for authenticity using the configured `delius.secret` key, and an OAuth2 access token will be returned on success.
 
 For example,
 ```shell script
-> curl -X POST -u test.web.client:secret "http://localhost:8080/umt/oauth2/token?u=${encryptedUsername}&t=${encryptedTimestamp}&client_id=test.web.client&grant_type=preauthenticated&scope=UMBI001"
+> curl -X POST -u test.web.client:secret "http://localhost:8080/umt/oauth/token?u=${encryptedUsername}&t=${encryptedTimestamp}&client_id=test.web.client&grant_type=preauthenticated&scope=UMBI001"
 < {"token_type":"bearer","access_token":"...","refresh_token":"...","expires_in":43199,"scope":"UMBI001"}
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,25 @@
 // Build plugins
 plugins {
-	id 'java'
-	id 'idea'
-	id 'jacoco'
-	id 'org.springframework.boot'               version '3.5.5'
-	id 'io.spring.dependency-management'        version '1.1.7'
-	id 'com.github.node-gradle.node'            version '7.1.0'
-	id 'io.gatling.gradle'                      version '3.14.5.1'
-	id 'com.gorylenko.gradle-git-properties'    version '2.5.3'
+    id 'java'
+    id 'idea'
+    id 'jacoco'
+    id 'org.springframework.boot'               version '3.5.5'
+    id 'io.spring.dependency-management'        version '1.1.7'
+    id 'com.github.node-gradle.node'            version '7.1.0'
+    id 'io.gatling.gradle'                      version '3.14.5.1'
+    id 'com.gorylenko.gradle-git-properties'    version '2.5.3'
 }
 
 // Java
 java {
-	toolchain { languageVersion = JavaLanguageVersion.of(21) }
+    toolchain { languageVersion = JavaLanguageVersion.of(21) }
 }
 
 // Spring Boot
 springBoot { buildInfo() }
 bootBuildImage {
-	environment['BPE_DELIM_JAVA_TOOL_OPTIONS'] = ' '
-	environment['BPE_APPEND_JAVA_TOOL_OPTIONS'] = '--add-opens=java.base/java.lang=ALL-UNNAMED'
+    environment['BPE_DELIM_JAVA_TOOL_OPTIONS'] = ' '
+    environment['BPE_APPEND_JAVA_TOOL_OPTIONS'] = '--add-opens=java.base/java.lang=ALL-UNNAMED'
 }
 bootRun.jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
 gitProperties { failOnNoGitDirectory = false }
@@ -45,38 +45,38 @@ clean { delete 'ui/dist' }
 jacoco.toolVersion '0.8.12'
 jacocoTestReport.reports.html.outputLocation.set(layout.buildDirectory.dir('reports/coverage/test'))
 tasks.named('test', Test).configure {
-	jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
-	finalizedBy jacocoTestReport
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
+    finalizedBy jacocoTestReport
 }
 
 // Project dependencies
 repositories { mavenCentral() }
 dependencies {
-	implementation      'org.springframework.boot:spring-boot-starter-web'
-	implementation      'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation      'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation      'org.springframework.boot:spring-boot-starter-data-ldap'
-	implementation      'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation      'org.springframework.boot:spring-boot-starter-actuator'
-	implementation      'org.springframework.boot:spring-boot-starter-security'
-	implementation      'org.springframework.boot:spring-boot-starter-validation'
-	implementation      'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation      'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
-	implementation      'org.springframework.session:spring-session-data-redis'
-	implementation      'com.unboundid:unboundid-ldapsdk'
-	implementation      'org.signal:embedded-redis:0.9.1'
+    implementation      'org.springframework.boot:spring-boot-starter-web'
+    implementation      'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation      'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation      'org.springframework.boot:spring-boot-starter-data-ldap'
+    implementation      'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation      'org.springframework.boot:spring-boot-starter-actuator'
+    implementation      'org.springframework.boot:spring-boot-starter-security'
+    implementation      'org.springframework.boot:spring-boot-starter-validation'
+    implementation      'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation      'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
+    implementation      'org.springframework.session:spring-session-data-redis'
+    implementation      'com.unboundid:unboundid-ldapsdk'
+    implementation      'org.signal:embedded-redis:0.9.1'
     implementation      'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
-	implementation      'com.opencsv:opencsv:5.12.0'
-	implementation      'io.github.resilience4j:resilience4j-bulkhead:2.3.0'
-	implementation      'io.github.resilience4j:resilience4j-spring-boot2:2.3.0'
-	compileOnly         'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	developmentOnly     'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly         'com.h2database:h2'
-	runtimeOnly         'com.oracle.database.jdbc:ojdbc11'
-	testImplementation  'org.junit.vintage:junit-vintage-engine'
-	testImplementation  'org.springframework.boot:spring-boot-starter-test'
-	testImplementation  'org.springframework.restdocs:spring-restdocs-mockmvc'
-	testImplementation  'org.springframework.security:spring-security-test'
+    implementation      'com.opencsv:opencsv:5.12.0'
+    implementation      'io.github.resilience4j:resilience4j-bulkhead:2.3.0'
+    implementation      'io.github.resilience4j:resilience4j-spring-boot2:2.3.0'
+    compileOnly         'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    developmentOnly     'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly         'com.h2database:h2'
+    runtimeOnly         'com.oracle.database.jdbc:ojdbc11'
+    testImplementation  'org.junit.vintage:junit-vintage-engine'
+    testImplementation  'org.springframework.boot:spring-boot-starter-test'
+    testImplementation  'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation  'org.springframework.security:spring-security-test'
 }

--- a/src/gatling/scala/MainSimulation.scala
+++ b/src/gatling/scala/MainSimulation.scala
@@ -15,7 +15,7 @@ class MainSimulation extends Simulation {
         .check(css("title").is("Sign in to National Delius"))
         .check(css("input[name=_csrf]", "value").saveAs("csrf"))
       ),
-      feed(Data.usernames).exec(http("SubmitCredentials").get("/oauth2/authorize")
+      feed(Data.usernames).exec(http("SubmitCredentials").get("/oauth/authorize")
         .basicAuth("${username}", Config.password)
         .queryParam("response_type", "code")
         .queryParam("client_id", "UserManagement-UI")
@@ -25,7 +25,7 @@ class MainSimulation extends Simulation {
         .check(status.is(200))
         .check(currentLocationRegex(".*code=([^&]*).*").saveAs("authorization_code"))
       ),
-      exec(http("GetAccessToken").post("/oauth2/token")
+      exec(http("GetAccessToken").post("/oauth/token")
         .basicAuth("UserManagement-UI", "")
         .queryParam("grant_type", "authorization_code")
         .queryParam("code", "${authorization_code}")

--- a/src/main/java/uk/co/bconline/ndelius/config/security/AuthorizationServerConfig.java
+++ b/src/main/java/uk/co/bconline/ndelius/config/security/AuthorizationServerConfig.java
@@ -84,7 +84,7 @@ public class AuthorizationServerConfig {
             .deviceAuthorizationEndpoint("/oauth/device_authorization")
             .deviceVerificationEndpoint("/oauth/device_verification")
             .tokenEndpoint("/oauth/token")
-            .tokenIntrospectionEndpoint("/oauth/introspect")
+            .tokenIntrospectionEndpoint("/oauth/check_token")
             .tokenRevocationEndpoint("/oauth/revoke")
             .jwkSetEndpoint("/oauth/jwks")
             .build();

--- a/src/main/java/uk/co/bconline/ndelius/config/security/AuthorizationServerConfig.java
+++ b/src/main/java/uk/co/bconline/ndelius/config/security/AuthorizationServerConfig.java
@@ -30,6 +30,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import uk.co.bconline.ndelius.config.security.converter.PreAuthenticatedGrantAuthenticationConverter;
 import uk.co.bconline.ndelius.config.security.converter.ScopeFilteringAuthorizationCodeRequestConverter;
+import uk.co.bconline.ndelius.config.security.handler.ContextRelativeRedirectAuthorizationEndpointSuccessHandler;
 import uk.co.bconline.ndelius.config.security.provider.PreAuthenticatedGrantAuthenticationProvider;
 
 @Configuration
@@ -65,7 +66,9 @@ public class AuthorizationServerConfig {
                     .accessTokenRequestConverter(preAuthenticatedGrantAuthenticationConverter)
                     .authenticationProvider(preAuthenticatedGrantAuthenticationProvider)
                 )
-                .authorizationEndpoint(endpoint -> endpoint.authorizationRequestConverter(new ScopeFilteringAuthorizationCodeRequestConverter())))
+                .authorizationEndpoint(endpoint -> endpoint
+                    .authorizationResponseHandler(new ContextRelativeRedirectAuthorizationEndpointSuccessHandler())
+                    .authorizationRequestConverter(new ScopeFilteringAuthorizationCodeRequestConverter())))
             .formLogin(formLogin -> formLogin.loginPage("/login").permitAll())
             .addFilterBefore(basicAuthenticationFilter, LogoutFilter.class) // To ensure basic authentication is applied before OAuthAuthorizationEndpointFilter
             .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))

--- a/src/main/java/uk/co/bconline/ndelius/config/security/handler/ContextRelativeRedirectAuthorizationEndpointSuccessHandler.java
+++ b/src/main/java/uk/co/bconline/ndelius/config/security/handler/ContextRelativeRedirectAuthorizationEndpointSuccessHandler.java
@@ -1,0 +1,48 @@
+package uk.co.bconline.ndelius.config.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationToken;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * ContextRelativeRedirectAuthorizationEndpointSuccessHandler is a customized version of org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter::sendAuthorizationResponse
+ * <p>
+ * The only difference from the original is that it allows relative redirect URIs outside the `/umt/` context root.
+ */
+public class ContextRelativeRedirectAuthorizationEndpointSuccessHandler implements AuthenticationSuccessHandler {
+    private final DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2AuthorizationCodeRequestAuthenticationToken authorizationCodeRequestAuthentication = (OAuth2AuthorizationCodeRequestAuthenticationToken) authentication;
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder
+            .fromUriString(authorizationCodeRequestAuthentication.getRedirectUri())
+            .queryParam(OAuth2ParameterNames.CODE,
+                authorizationCodeRequestAuthentication.getAuthorizationCode().getTokenValue());
+        if (StringUtils.hasText(authorizationCodeRequestAuthentication.getState())) {
+            uriBuilder.queryParam(OAuth2ParameterNames.STATE,
+                UriUtils.encode(authorizationCodeRequestAuthentication.getState(), StandardCharsets.UTF_8));
+        }
+        // build(true) -> Components are explicitly encoded
+        String redirectUri = uriBuilder.build(true).toUriString();
+        if (!UrlUtils.isAbsoluteUrl(redirectUri)) {
+            // For relative paths, bypass the default redirect strategy and redirect to the path explicitly
+            response.encodeRedirectURL(redirectUri);
+            response.sendRedirect(redirectUri);
+        } else {
+            this.redirectStrategy.sendRedirect(request, response, redirectUri);
+        }
+    }
+}

--- a/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
+++ b/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.val;
 import org.springframework.ldap.odm.annotations.Attribute;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
@@ -16,9 +17,11 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import uk.co.bconline.ndelius.config.security.token.PreAuthenticatedGrantAuthenticationToken;
 import uk.co.bconline.ndelius.util.AuthUtils;
 
 import javax.naming.Name;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
@@ -59,7 +62,13 @@ public final class ClientEntry {
             .clientSecret(clientSecret)
             .clientAuthenticationMethods(methods -> {
                 methods.add(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
-                if (authorizedGrantTypes != null && !authorizedGrantTypes.contains(AuthorizationGrantType.CLIENT_CREDENTIALS.getValue())) {
+
+                // Allow public clients to skip authentication
+                val publicClientGrantTypes = List.of(
+                    AuthorizationGrantType.AUTHORIZATION_CODE.getValue(),
+                    PreAuthenticatedGrantAuthenticationToken.PREAUTHENTICATED
+                );
+                if (clientSecret == null && authorizedGrantTypes != null && authorizedGrantTypes.stream().anyMatch(publicClientGrantTypes::contains)) {
                     methods.add(ClientAuthenticationMethod.NONE);
                 }
             })

--- a/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
+++ b/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.val;
 import org.springframework.ldap.odm.annotations.Attribute;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
@@ -17,11 +16,9 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
-import uk.co.bconline.ndelius.config.security.token.PreAuthenticatedGrantAuthenticationToken;
 import uk.co.bconline.ndelius.util.AuthUtils;
 
 import javax.naming.Name;
-import java.util.List;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
@@ -64,11 +61,7 @@ public final class ClientEntry {
                 methods.add(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
 
                 // Allow public clients to skip authentication
-                val publicClientGrantTypes = List.of(
-                    AuthorizationGrantType.AUTHORIZATION_CODE.getValue(),
-                    PreAuthenticatedGrantAuthenticationToken.PREAUTHENTICATED
-                );
-                if (clientSecret == null && authorizedGrantTypes != null && authorizedGrantTypes.stream().anyMatch(publicClientGrantTypes::contains)) {
+                if (clientSecret == null && authorizedGrantTypes != null && authorizedGrantTypes.contains(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())) {
                     methods.add(ClientAuthenticationMethod.NONE);
                 }
             })

--- a/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
+++ b/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
@@ -75,9 +75,7 @@ public final class ClientEntry {
             .clientSettings(ClientSettings.builder().requireAuthorizationConsent(false).build())
             .tokenSettings(TokenSettings.builder().accessTokenFormat(OAuth2TokenFormat.REFERENCE).build())
             .scopes(scopes -> scopes.addAll(AuthUtils.mapToScopes(roles).collect(toSet())))
-            .redirectUris(uris -> uris.addAll(registeredRedirectUri.stream()
-                // Workaround for the new redirect strategy in spring authorization server. See org.springframework.security.web.DefaultRedirectStrategy
-                .map(uri -> "/umt/".equals(uri) ? "/" : uri).collect(toSet())))
+            .redirectUris(uris -> uris.addAll(registeredRedirectUri))
             .authorizationGrantTypes(types -> authorizedGrantTypes.stream().map(AuthorizationGrantType::new).forEach(types::add))
             .build();
     }

--- a/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
+++ b/src/main/java/uk/co/bconline/ndelius/model/entry/ClientEntry.java
@@ -76,7 +76,10 @@ public final class ClientEntry {
             .tokenSettings(TokenSettings.builder().accessTokenFormat(OAuth2TokenFormat.REFERENCE).build())
             .scopes(scopes -> scopes.addAll(AuthUtils.mapToScopes(roles).collect(toSet())))
             .redirectUris(uris -> uris.addAll(registeredRedirectUri))
-            .authorizationGrantTypes(types -> authorizedGrantTypes.stream().map(AuthorizationGrantType::new).forEach(types::add))
+            .authorizationGrantTypes(types -> {
+                authorizedGrantTypes.stream().map(AuthorizationGrantType::new).forEach(types::add);
+                if (types.isEmpty()) types.add(AuthorizationGrantType.CLIENT_CREDENTIALS);
+            })
             .build();
     }
 }

--- a/src/main/java/uk/co/bconline/ndelius/service/impl/UserEntryServiceImpl.java
+++ b/src/main/java/uk/co/bconline/ndelius/service/impl/UserEntryServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.filter.AndFilter;
 import org.springframework.ldap.filter.OrFilter;
@@ -52,6 +53,7 @@ import static uk.co.bconline.ndelius.util.NameUtils.join;
 
 @Slf4j
 @Service
+@Primary
 public class UserEntryServiceImpl implements UserEntryService, UserDetailsService {
 
     @Value("${spring.ldap.base}")

--- a/src/main/java/uk/co/bconline/ndelius/util/AuthUtils.java
+++ b/src/main/java/uk/co/bconline/ndelius/util/AuthUtils.java
@@ -4,6 +4,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -40,6 +41,7 @@ public class AuthUtils {
                 return switch (principal) {
                     case UserDetails userDetails -> userDetails.getUsername();
                     case RegisteredClient registeredClient -> registeredClient.getClientId();
+                    case UsernamePasswordAuthenticationToken usernamePassword -> usernamePassword.getName();
                     case
                         OAuth2AuthenticatedPrincipal oauth2Principal when PREAUTHENTICATED.equals(oauth2Principal.getAttribute("grant_type")) ->
                         oauth2Principal.getAttribute("username");

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,62 +1,62 @@
 {
-  "properties": [
-    {
-      "name": "spring.ldap.default-password",
-      "type": "java.lang.String",
-      "description": "Default SHA/SSHA hashed password to be used when creating users in LDAP."
-    },
-    {
-      "name": "delius.secret",
-      "type": "java.lang.String",
-      "description": "Shared secret key between National Delius and UMT, to support delegated authentication via request parameters."
-    },
-    {
-      "name": "delius.ldap.base.users",
-      "type": "java.lang.String",
-      "description": "Base entry for Users in the LDAP."
-    },
-    {
-      "name": "delius.ldap.base.groups",
-      "type": "java.lang.String",
-      "description": "Base entry for Groups in the LDAP."
-    },
-    {
-      "name": "delius.ldap.base.clients",
-      "type": "java.lang.String",
-      "description": "Base entry for OAuth Clients in the LDAP."
-    },
-    {
-      "name": "delius.ldap.base.roles",
-      "type": "java.lang.String",
-      "description": "Base entry for the Role Catalogue in the LDAP."
-    },
-    {
-      "name": "delius.ldap.base.role-groups",
-      "type": "java.lang.String",
-      "description": "Base entry for the RoleGroup Catalogue in the LDAP."
-    },
-    {
-      "name": "cache.evict.delay",
-      "type": "java.lang.String",
-      "description": "How often the Database and LDAP caches should be cleared, in milliseconds. Defaults to 24 hours."
-    },
-    {
-      "name": "spring.ldap.useOracleAttributes",
-      "type": "java.lang.Boolean",
-      "defaultValue": true,
-      "description": "Whether to use the 'orclActiveStartDate' and 'orclActiveEndDate' attributes instead of the 'startDate' and 'endDate' attributes in the User LDAP entry."
-    },
-    {
-        "name": "spring.data.redis.embedded",
-      "type": "java.lang.Boolean",
-      "defaultValue": false,
-      "description": "Whether to enable the in-memory Redis server on port ${spring.redis.port} for the OAuth token store."
-    },
-    {
-      "name": "redis.configure.no-op",
-      "type": "java.lang.Boolean",
-      "defaultValue": false,
-      "description": "Creates a NO-OP bean for Redis configuration. This prevents Spring from automatically attempting to update the configuration on the Redis cluster."
-    }
-  ]
+    "properties": [
+        {
+            "name": "spring.ldap.default-password",
+            "type": "java.lang.String",
+            "description": "Default SHA/SSHA hashed password to be used when creating users in LDAP."
+        },
+        {
+            "name": "delius.secret",
+            "type": "java.lang.String",
+            "description": "Shared secret key between National Delius and UMT, to support delegated authentication via request parameters."
+        },
+        {
+            "name": "delius.ldap.base.users",
+            "type": "java.lang.String",
+            "description": "Base entry for Users in the LDAP."
+        },
+        {
+            "name": "delius.ldap.base.groups",
+            "type": "java.lang.String",
+            "description": "Base entry for Groups in the LDAP."
+        },
+        {
+            "name": "delius.ldap.base.clients",
+            "type": "java.lang.String",
+            "description": "Base entry for OAuth Clients in the LDAP."
+        },
+        {
+            "name": "delius.ldap.base.roles",
+            "type": "java.lang.String",
+            "description": "Base entry for the Role Catalogue in the LDAP."
+        },
+        {
+            "name": "delius.ldap.base.role-groups",
+            "type": "java.lang.String",
+            "description": "Base entry for the RoleGroup Catalogue in the LDAP."
+        },
+        {
+            "name": "cache.evict.delay",
+            "type": "java.lang.String",
+            "description": "How often the Database and LDAP caches should be cleared, in milliseconds. Defaults to 24 hours."
+        },
+        {
+            "name": "spring.ldap.useOracleAttributes",
+            "type": "java.lang.Boolean",
+            "defaultValue": true,
+            "description": "Whether to use the 'orclActiveStartDate' and 'orclActiveEndDate' attributes instead of the 'startDate' and 'endDate' attributes in the User LDAP entry."
+        },
+        {
+            "name": "spring.data.redis.embedded",
+            "type": "java.lang.Boolean",
+            "defaultValue": false,
+            "description": "Whether to enable the in-memory Redis server on port ${spring.redis.port} for the OAuth token store."
+        },
+        {
+            "name": "redis.configure.no-op",
+            "type": "java.lang.Boolean",
+            "defaultValue": false,
+            "description": "Creates a NO-OP bean for Redis configuration. This prevents Spring from automatically attempting to update the configuration on the Redis cluster."
+        }
+    ]
 }

--- a/src/test/java/uk/co/bconline/ndelius/config/security/AuthorizationServerConfigTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/AuthorizationServerConfigTest.java
@@ -41,7 +41,7 @@ public class AuthorizationServerConfigTest {
 
 	@Test
 	public void noCredentialsReturnsUnauthorized() throws Exception {
-		mvc.perform(post("/oauth2/token"))
+		mvc.perform(post("/oauth/token"))
 				.andExpect(status().isUnauthorized());
 	}
 
@@ -78,7 +78,7 @@ public class AuthorizationServerConfigTest {
 	public void tokenCanBeUsedToAuthoriseBothRolesAndInteractions() throws Exception {
 		String authCode = TokenUtils.getAuthCode(mvc, "test.user");
 
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.web.client", "secret"))
 				.param("code", authCode)
 				.param("grant_type", "authorization_code")

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/AuthorizationCodeAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/AuthorizationCodeAuthTest.java
@@ -86,7 +86,7 @@ public class AuthorizationCodeAuthTest {
             .andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString(), "access_token");
 
-        mvc.perform(post("/oauth/introspect")
+        mvc.perform(post("/oauth/check_token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", token))
             .andExpect(status().isOk())

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/AuthorizationCodeAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/AuthorizationCodeAuthTest.java
@@ -42,7 +42,7 @@ public class AuthorizationCodeAuthTest {
 
     @Test
     public void invalidUserCredentialsReturnsUnauthorized() throws Exception {
-        mvc.perform(get("/oauth2/authorize")
+        mvc.perform(get("/oauth/authorize")
                 .with(httpBasic("INVALID", "INVALID"))
                 .queryParam("client_id", "test.web.client")
                 .queryParam("response_type", "code")
@@ -52,7 +52,7 @@ public class AuthorizationCodeAuthTest {
 
     @Test
     public void successfulLoginRedirectsWithAuthorizationCodeInQueryParams() throws Exception {
-        mvc.perform(get("/oauth2/authorize")
+        mvc.perform(get("/oauth/authorize")
                 .with(httpBasic("test.user", "secret"))
                 .queryParam("client_id", "test.web.client")
                 .queryParam("response_type", "code")
@@ -65,7 +65,7 @@ public class AuthorizationCodeAuthTest {
     public void invalidClientLoginIsUnauthorized() throws Exception {
         String authCode = getAuthCode(mvc, "test.user");
 
-        mvc.perform(post("/oauth2/token")
+        mvc.perform(post("/oauth/token")
                 .with(httpBasic("INVALID", "INVALID"))
                 .param("code", authCode)
                 .param("grant_type", "authorization_code"))
@@ -77,7 +77,7 @@ public class AuthorizationCodeAuthTest {
     public void userScopesAreReturnedCorrectly() throws Exception {
         String authCode = getAuthCode(mvc, "test.user", "UMBI001");
         String token = JsonPath.read(mvc.perform(
-                post("/oauth2/token")
+                post("/oauth/token")
                     .with(httpBasic("test.web.client", "secret"))
                     .param("code", authCode)
                     .param("grant_type", "authorization_code")
@@ -86,7 +86,7 @@ public class AuthorizationCodeAuthTest {
             .andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString(), "access_token");
 
-        mvc.perform(post("/oauth2/introspect")
+        mvc.perform(post("/oauth/introspect")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", token))
             .andExpect(status().isOk())
@@ -100,7 +100,7 @@ public class AuthorizationCodeAuthTest {
     public void authorizationCodeCanBeSwappedForAccessToken() throws Exception {
         String authCode = getAuthCode(mvc, "test.user");
 
-        mvc.perform(post("/oauth2/token")
+        mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("code", authCode)
                 .param("grant_type", "authorization_code")
@@ -120,7 +120,7 @@ public class AuthorizationCodeAuthTest {
 
     @Test
     public void pathBasedRedirectUriCanBeUsed() throws Exception {
-        mvc.perform(get("/oauth2/authorize")
+        mvc.perform(get("/oauth/authorize")
                 .with(httpBasic("test.user", "secret"))
                 .queryParam("client_id", "test.web.client")
                 .queryParam("redirect_uri", "/login-success")

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/ClientCredentialsAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/ClientCredentialsAuthTest.java
@@ -45,7 +45,7 @@ public class ClientCredentialsAuthTest
 	@Test
 	public void invalidClientCredentialsReturnsUnauthorized() throws Exception
 	{
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("INVALID", "INVALID"))
 				.param("grant_type", "client_credentials"))
 				.andExpect(status().isUnauthorized());
@@ -54,7 +54,7 @@ public class ClientCredentialsAuthTest
 	@Test
 	public void successfulClientLoginReturnsBearerToken() throws Exception
 	{
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.server.client", "secret"))
 				.param("grant_type", "client_credentials"))
 				.andExpect(status().isOk())

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/PreAuthenticatedAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/PreAuthenticatedAuthTest.java
@@ -44,7 +44,7 @@ public class PreAuthenticatedAuthTest {
 
 	@Test
 	public void canLoginWithEncryptedRequestParams() throws Exception {
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.web.client", "secret"))
 				.queryParam("u", encrypt("test.user", "ThisIsASecretKey"))
 				.queryParam("t", encrypt(String.valueOf(now().toEpochMilli()), "ThisIsASecretKey"))
@@ -58,7 +58,7 @@ public class PreAuthenticatedAuthTest {
 
 	@Test
 	public void userScopesAreReturnedCorrectly() throws Exception {
-        String token = JsonPath.read(mvc.perform(post("/oauth2/token")
+        String token = JsonPath.read(mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.web.client", "secret"))
 				.queryParam("u", encrypt("test.user", "ThisIsASecretKey"))
 				.queryParam("t", encrypt(String.valueOf(now().toEpochMilli()), "ThisIsASecretKey"))
@@ -67,7 +67,7 @@ public class PreAuthenticatedAuthTest {
 				.andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString(), "access_token");
 
-        mvc.perform(post("/oauth2/introspect")
+        mvc.perform(post("/oauth/introspect")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", token))
             .andExpect(status().isOk())
@@ -79,7 +79,7 @@ public class PreAuthenticatedAuthTest {
 
 	@Test
     public void missingTimestampIsBadRequest() throws Exception {
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.web.client", "secret"))
 				.queryParam("u", encrypt("test.user", "ThisIsASecretKey"))
 				.param("grant_type", "preauthenticated")
@@ -89,7 +89,7 @@ public class PreAuthenticatedAuthTest {
 
 	@Test
 	public void timestampOutOfDateIsUnauthorized() throws Exception {
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.web.client", "secret"))
 				.queryParam("u", encrypt("test.user", "ThisIsASecretKey"))
 				.queryParam("t", encrypt(String.valueOf(now().minus(2, HOURS).toEpochMilli()), "ThisIsASecretKey"))
@@ -100,7 +100,7 @@ public class PreAuthenticatedAuthTest {
 
 	@Test
 	public void incorrectKeyIsUnauthorized() throws Exception {
-		mvc.perform(post("/oauth2/token")
+		mvc.perform(post("/oauth/token")
 				.with(httpBasic("test.web.client", "secret"))
 				.queryParam("u", encrypt("test.user", "INVALID-KEY"))
 				.queryParam("t", encrypt(String.valueOf(now().toEpochMilli()), "INVALID-KEY"))
@@ -111,7 +111,7 @@ public class PreAuthenticatedAuthTest {
 
     @Test
     public void incorrectClientSecretIsUnauthorized() throws Exception {
-        mvc.perform(post("/oauth2/token")
+        mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "INVALID-SECRET"))
                 .queryParam("u", encrypt("test.user", "ThisIsASecretKey"))
                 .queryParam("t", encrypt(String.valueOf(now().toEpochMilli()), "ThisIsASecretKey"))

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/PreAuthenticatedAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/PreAuthenticatedAuthTest.java
@@ -67,7 +67,7 @@ public class PreAuthenticatedAuthTest {
 				.andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString(), "access_token");
 
-        mvc.perform(post("/oauth/introspect")
+        mvc.perform(post("/oauth/check_token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", token))
             .andExpect(status().isOk())

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/RefreshTokenAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/RefreshTokenAuthTest.java
@@ -75,7 +75,7 @@ public class RefreshTokenAuthTest {
         String accessToken = JsonPath.read(accessTokenResponse, "access_token");
         String refreshToken = JsonPath.read(accessTokenResponse, "refresh_token");
 
-        String accessTokenDetails = mvc.perform(post("/oauth/introspect")
+        String accessTokenDetails = mvc.perform(post("/oauth/check_token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", accessToken))
             .andExpect(status().isOk())
@@ -89,7 +89,7 @@ public class RefreshTokenAuthTest {
             .andExpect(jsonPath("access_token", notNullValue()))
             .andReturn().getResponse().getContentAsString(), "access_token");
 
-        mvc.perform(post("/oauth/introspect")
+        mvc.perform(post("/oauth/check_token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", newAccessToken))
             .andExpect(status().isOk())

--- a/src/test/java/uk/co/bconline/ndelius/config/security/auth/RefreshTokenAuthTest.java
+++ b/src/test/java/uk/co/bconline/ndelius/config/security/auth/RefreshTokenAuthTest.java
@@ -44,7 +44,7 @@ public class RefreshTokenAuthTest {
 
     @Test
     public void tokenCanBeRefreshed() throws Exception {
-        String refreshToken = JsonPath.read(mvc.perform(post("/oauth2/token")
+        String refreshToken = JsonPath.read(mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("code", getAuthCode(mvc, "test.user"))
                 .param("grant_type", "authorization_code")
@@ -54,7 +54,7 @@ public class RefreshTokenAuthTest {
             .getResponse()
             .getContentAsString(), "refresh_token");
 
-        mvc.perform(post("/oauth2/token")
+        mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("grant_type", "refresh_token")
                 .param("refresh_token", refreshToken))
@@ -65,7 +65,7 @@ public class RefreshTokenAuthTest {
 
     @Test
     public void preAuthenticatedTokenCanBeRefreshed() throws Exception {
-        String accessTokenResponse = mvc.perform(post("/oauth2/token")
+        String accessTokenResponse = mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("u", encrypt("test.user", "ThisIsASecretKey"))
                 .param("t", encrypt(String.valueOf(now().toEpochMilli()), "ThisIsASecretKey"))
@@ -75,13 +75,13 @@ public class RefreshTokenAuthTest {
         String accessToken = JsonPath.read(accessTokenResponse, "access_token");
         String refreshToken = JsonPath.read(accessTokenResponse, "refresh_token");
 
-        String accessTokenDetails = mvc.perform(post("/oauth2/introspect")
+        String accessTokenDetails = mvc.perform(post("/oauth/introspect")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", accessToken))
             .andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString();
 
-        String newAccessToken = JsonPath.read(mvc.perform(post("/oauth2/token")
+        String newAccessToken = JsonPath.read(mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("grant_type", "refresh_token")
                 .param("refresh_token", refreshToken))
@@ -89,7 +89,7 @@ public class RefreshTokenAuthTest {
             .andExpect(jsonPath("access_token", notNullValue()))
             .andReturn().getResponse().getContentAsString(), "access_token");
 
-        mvc.perform(post("/oauth2/introspect")
+        mvc.perform(post("/oauth/introspect")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("token", newAccessToken))
             .andExpect(status().isOk())

--- a/src/test/java/uk/co/bconline/ndelius/test/util/TokenUtils.java
+++ b/src/test/java/uk/co/bconline/ndelius/test/util/TokenUtils.java
@@ -26,7 +26,7 @@ public class TokenUtils {
     }
 
     public static String getAuthCode(MockMvc mvc, String username, String scopes) throws Exception {
-        return fromUriString(requireNonNull(mvc.perform(get("/oauth2/authorize")
+        return fromUriString(requireNonNull(mvc.perform(get("/oauth/authorize")
                 .with(httpBasic(username, "secret"))
                 .queryParam("client_id", "test.web.client")
                 .queryParam("response_type", "code")
@@ -44,7 +44,7 @@ public class TokenUtils {
     public static String authCodeToken(MockMvc mvc, String username) throws Exception {
         String authCode = getAuthCode(mvc, username);
 
-        return JsonPath.read(mvc.perform(post("/oauth2/token")
+        return JsonPath.read(mvc.perform(post("/oauth/token")
                 .with(httpBasic("test.web.client", "secret"))
                 .param("code", authCode)
                 .param("grant_type", "authorization_code")
@@ -56,7 +56,7 @@ public class TokenUtils {
     }
 
     public static String clientCredentialsToken(MockMvc mvc, String clientId) throws Exception {
-        return JsonPath.read(mvc.perform(post("/oauth2/token")
+        return JsonPath.read(mvc.perform(post("/oauth/token")
                 .with(httpBasic(clientId, "secret"))
                 .param("grant_type", "client_credentials")
                 .param("resource_id", "NDelius"))

--- a/ui/src/environments/environment.dev.ts
+++ b/ui/src/environments/environment.dev.ts
@@ -12,8 +12,8 @@ const authConfig: AuthConfig = {
   responseType: 'code',
   oidc: false,
   requireHttps: false,
-  loginUrl: 'http://localhost:8080/umt/oauth2/authorize',
-  tokenEndpoint: 'http://localhost:8080/umt/oauth2/token',
+  loginUrl: 'http://localhost:8080/umt/oauth/authorize',
+  tokenEndpoint: 'http://localhost:8080/umt/oauth/token',
   redirectUri: window.location.origin + '/umt/',
 };
 

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -14,7 +14,7 @@ const authConfig: AuthConfig = {
   requireHttps: false,
   loginUrl: '/umt/oauth/authorize',
   tokenEndpoint: '/umt/oauth/token',
-  redirectUri: '/', // Spring's redirect strategy is not context-relative, so requesting "/" actually redirects to "/umt/". See org.springframework.security.web.DefaultRedirectStrategy
+  redirectUri: '/umt/',
 };
 
 export const environment = {

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -12,8 +12,8 @@ const authConfig: AuthConfig = {
   responseType: 'code',
   oidc: false,
   requireHttps: false,
-  loginUrl: '/umt/oauth2/authorize',
-  tokenEndpoint: '/umt/oauth2/token',
+  loginUrl: '/umt/oauth/authorize',
+  tokenEndpoint: '/umt/oauth/token',
   redirectUri: '/', // Spring's redirect strategy is not context-relative, so requesting "/" actually redirects to "/umt/". See org.springframework.security.web.DefaultRedirectStrategy
 };
 

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -16,8 +16,8 @@ const authConfig: AuthConfig = {
   responseType: 'code',
   oidc: false,
   requireHttps: false,
-  loginUrl: 'http://localhost:8080/umt/oauth2/authorize',
-  tokenEndpoint: 'http://localhost:8080/umt/oauth2/token',
+  loginUrl: 'http://localhost:8080/umt/oauth/authorize',
+  tokenEndpoint: 'http://localhost:8080/umt/oauth/token',
   redirectUri: window.location.origin + '/umt/',
 };
 


### PR DESCRIPTION
* Updates OAuth2 URL paths to match Spring Boot 2 behaviour
* Re-implemented the PathMatchRedirectResolver as ContextRelativeRedirectAuthorizationEndpointSuccessHandler
* Default to client_credentials if no authorized grant types are configured on the LDAP client
* Update public client check to confirm userPassword is null and authorized grant type contains either authorization_code or preauthenticated